### PR TITLE
small fix for case sensitive DBMS

### DIFF
--- a/testlib.php
+++ b/testlib.php
@@ -215,8 +215,8 @@ class report_benchmark_test extends report_benchmark {
                          COALESCE (bp.weight, bi.defaultweight) AS weight,
                          bi.configdata,
                          ctx.id AS ctxid,
-                         ctx.PATH AS ctxpath,
-                         ctx.DEPTH AS ctxdepth,
+                         ctx.path AS ctxpath,
+                         ctx.depth AS ctxdepth,
                          ctx.contextlevel AS ctxlevel,
                          ctx.instanceid AS ctxinstance
                     FROM {block_instances} bi


### PR DESCRIPTION
When using a case sensitive DBMS an error is thrown because 'path' and 'depth' fields are in upper case in SQL request.