### PR TITLE
Use private temporary folder for performance tests

### DIFF
--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Remove the temporary directory if it exists
+ *
+ * @return true
+ */
+
+function xmldb_report_benchmark_uninstall()
+{
+    global $CFG;
+
+    $tempfolder=$CFG->tempdir.'/report_benchmark';
+
+    remove_dir($tempfolder);
+
+    return true;
+}

--- a/testlib.php
+++ b/testlib.php
@@ -112,17 +112,20 @@ class report_benchmark_test extends report_benchmark {
     public static function fileread() {
         global $CFG;
 
-        file_put_contents($CFG->tempdir.'/benchmark.temp', 'benchmark');
+        $tempfolder=$CFG->tempdir.'/report_benchmark';
+
+        check_dir_exists($tempfolder,true);
+
+        file_put_contents($tempfolder.'/benchmark.temp', 'benchmark');
         $i      = 0;
         $pass   = 2000;
         while ($i < $pass) {
             ++$i;
-            file_get_contents($CFG->tempdir.'/benchmark.temp');
+            file_get_contents($tempfolder.'/benchmark.temp');
         }
-        unlink($CFG->tempdir.'/benchmark.temp');
+        unlink($tempfolder.'/benchmark.temp');
 
         return array('limit' => .5, 'over' => .8, 'fail' => BENCHFAIL_SLOWHARDDRIVE);
-
     }
 
     /**


### PR DESCRIPTION
We felt that even though the write and read to the temporary folder is currently quite trivial, it should still go into its own subfolder so this feature branch adds report_benchmark to the CFG->tempdir path and the plugin then writes to that.